### PR TITLE
feat: use env vars instead of public tokens

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       for (const i of (await (await fetch ('https://api.github.com/orgs/is-a-dev/members', {
         method: 'GET',
         headers: {
-          'Authorization': `token ${(await fetch('https://raw.githubusercontent.com/is-a-dev/maintainer-docs/gh-pages/token.txt').then(r => r.text())).replace(/\-/g, '')}`
+          'Authorization': `token ${process.env.GH_TOKEN}`
         }
       })).json ())) {
         document.getElementById ('contributers').innerHTML += `

--- a/token.txt
+++ b/token.txt
@@ -1,1 +1,0 @@
-g-h-p-_-e-n-B-l-E-c-a-7-U-Y-7-u-v-5-x-s-x-L-n-1-Y-R-B-7-w-4-a-k-B-c-4-X-q-t-U-E


### PR DESCRIPTION
this use the env vars and make token safer.